### PR TITLE
SyntaxHighlighter: Inherit Mode before QtGui.QSyntaxHighlighter

### DIFF
--- a/pyqodeng/core/api/syntax_highlighter.py
+++ b/pyqodeng/core/api/syntax_highlighter.py
@@ -196,7 +196,7 @@ class ColorScheme:
         return qcolor
 
 
-class SyntaxHighlighter(QtGui.QSyntaxHighlighter, Mode):
+class SyntaxHighlighter(Mode, QtGui.QSyntaxHighlighter):
     """
     Abstract base class for syntax highlighter modes.
 


### PR DESCRIPTION
With PySide6 6.5.0, `QSyntaxHighlighter` will invoke additional constructors, with `parent` argument passed to them, causing an exception in `Move.__init__` which takes no additional arguments. Simply move `Mode` before `QSyntaxHighlighter` to fix this issue.