### PR TITLE
Use string representation for QKeySequence construction

### DIFF
--- a/pyqodeng/core/api/code_edit.py
+++ b/pyqodeng/core/api/code_edit.py
@@ -1284,15 +1284,13 @@ class CodeEdit(QtWidgets.QPlainTextEdit):
         self.action_duplicate_line = action
         # swap line up
         action = QtWidgets.QAction(_('Swap line up'), self)
-        action.setShortcut(QtGui.QKeySequence(
-            QtCore.Qt.AltModifier | QtCore.Qt.Key_Up))
+        action.setShortcut(QtGui.QKeySequence('Alt+Up'))
         action.triggered.connect(self.swapLineUp)
         self.add_action(action, sub_menu=None)
         self.action_swap_line_up = action
         # swap line down
         action = QtWidgets.QAction(_('Swap line down'), self)
-        action.setShortcut(QtGui.QKeySequence(
-            QtCore.Qt.AltModifier | QtCore.Qt.Key_Down))
+        action.setShortcut(QtGui.QKeySequence('Alt+Down'))
         action.triggered.connect(self.swapLineDown)
         self.add_action(action, sub_menu=None)
         self.action_swap_line_down = action


### PR DESCRIPTION
This style is used elsewhere, and fixes an issue on PySide 6.6.2 where the operator style construction is now broken.